### PR TITLE
Typo; used predFakeA instead of predFakeB

### DIFF
--- a/models/CycleGan.py
+++ b/models/CycleGan.py
@@ -111,7 +111,7 @@ class CycleGan(pl.LightningModule):
         mseRealB = self.get_mse_loss(predRealB, 'real')
         
         predFakeB = self.disY(fakeB)
-        mseFakeB = self.get_mse_loss(predFakeA, 'fake')
+        mseFakeB = self.get_mse_loss(predFakeB, 'fake')
         
         # gather all losses
         self.disLoss = 0.5 * (mseFakeA + mseRealA + mseFakeB + mseRealB)


### PR DESCRIPTION
Due to the typo the model does not learn mapping from A to B. Even B to A is not good.